### PR TITLE
Automatic trigger for objectWillChange publisher

### DIFF
--- a/Sources/AsyncValue/AsyncValue.swift
+++ b/Sources/AsyncValue/AsyncValue.swift
@@ -147,7 +147,7 @@ public struct AsyncValue<Value: Equatable> {
         set {
             // Trigger the `ObjectWillChangePublisher`
             instance.objectWillChange.send()
-            instance[keyPath: storageKeyPath].storage.yield(newValue)
+            instance[keyPath: storageKeyPath].wrappedValue = newValue
         }
     }
 

--- a/Tests/AsyncValueTests/AsyncValueTests.swift
+++ b/Tests/AsyncValueTests/AsyncValueTests.swift
@@ -67,11 +67,7 @@ import SwiftUI
 
 extension AsyncValueTests {
     fileprivate class TestObservableObject: ObservableObject {
-        var cancellable: AnyCancellable?
-        
-        @AsyncValue var myValue = "Test" {
-            willSet { objectWillChange.send() }
-        }
+        @AsyncValue var myValue = "Test"
     }
 
     func test_observableObjectPublisher() {
@@ -81,7 +77,7 @@ extension AsyncValueTests {
         
         var updateCount: Int = 0
         
-        sut.cancellable = sut.objectWillChange.sink {
+        let cancellable = sut.objectWillChange.sink {
             updateCount += 1
         }
         
@@ -96,6 +92,7 @@ extension AsyncValueTests {
         // Since we subscribed after the observable object is created, the initial state of "Test".
         // Cannot trigger a new value in our sink block above.
         XCTAssertEqual(updateCount, 2)
+        cancellable.cancel()
     }
 }
 #endif


### PR DESCRIPTION
Automatically triggers the `objectWillChange` publisher in `Combine`s `ObservableObject`.

Heavily inspired by [John Sundell](https://www.swiftbysundell.com/articles/accessing-a-swift-property-wrappers-enclosing-instance/) and the `@propertyWrapper` [Swift Evolution Proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type).

fixes #5 